### PR TITLE
Fix SerializableCallback submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Submodules/xNode"]
 	path = Submodules/xNode
 	url = https://github.com/Siccity/xNode.git
-[submodule "Submodules\\SerializableCallback"]
-	path = Submodules\\SerializableCallback
+[submodule "Submodules/SerializableCallback"]
+	path = Submodules/SerializableCallback
 	url = https://github.com/Siccity/SerializableCallback.git


### PR DESCRIPTION
Submodules cannot be initialised unless SerializableCallback path is corrected. 

Thank you for your great work.
First issue I had is that I was not able to init submodules.
I corrected the SerializableCallback path and it worked.

Please consider merging this.

